### PR TITLE
appease the dialyzer

### DIFF
--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -60,6 +60,7 @@
                 | {indent, non_neg_integer()}
                 | {depth, non_neg_integer()}
                 | {newline, binary()}
+                | {float_formatter, fun((any()) -> any())}
                 | legacy_option()
                 | {legacy_option(), boolean()}.
 -type legacy_option() :: strict_comments

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -421,7 +421,12 @@ encode_with_float_formatter_test_() ->
         {"foo formatter",
             ?_assert(
                 encode(float, 3.1234567890987654321, #config{float_formatter = fun ?MODULE:custom_float_formatter/1 }) =:= ["foo"])
-        }
+        },
+        {"encoded floats with formatter are floats in output",
+            ?_assertEqual(
+               <<"{\"one\":{\"two\":3.1235}}">>,
+               jsx:encode(#{one => #{two => 3.1234567890987654321}}, [{float_formatter, fun(F) -> io_lib:format("~.4f", [F]) end}])
+            )}
     ].
 
 -endif.


### PR DESCRIPTION
- add a test to make sure encoded maps don't represent floats as float-strings.